### PR TITLE
Add possibility to become object by proxy

### DIFF
--- a/Avatar.package/AvDelegationProxy.class/class/becomeTarget.handler..st
+++ b/Avatar.package/AvDelegationProxy.class/class/becomeTarget.handler..st
@@ -1,0 +1,7 @@
+instance-creation
+becomeTarget: anObject handler: aHandler
+	| proxy |
+	proxy := self target: anObject handler: aHandler.
+	anObject become: proxy.
+	MirrorPrimitives fixedFieldOf: anObject at: (self slotNamed: #target) index put: proxy.
+	^ anObject

--- a/Avatar.package/AvDelegationProxyTest.class/instance/testReplaceTargetReferences.st
+++ b/Avatar.package/AvDelegationProxyTest.class/instance/testReplaceTargetReferences.st
@@ -1,0 +1,10 @@
+tests
+testReplaceTargetReferences
+	| result |
+	handler := AvTestLogAndResendHandler new.
+	target := Point x: 1 y: 2.
+	AvDelegationProxy becomeTarget: target handler: handler.
+	result := target x.
+	self assert: result equals: 1.
+	self assert: handler messages notEmpty.
+	self assert: handler messages first message selector equals: #x

--- a/Avatar.package/AvForwardingProxy.class/class/becomeTarget.handler..st
+++ b/Avatar.package/AvForwardingProxy.class/class/becomeTarget.handler..st
@@ -1,0 +1,7 @@
+instance-creation
+becomeTarget: anObject handler: aHandler
+	| proxy |
+	proxy := self target: anObject handler: aHandler.
+	anObject become: proxy.
+	MirrorPrimitives fixedFieldOf: anObject at: (self slotNamed: #target) index put: proxy.
+	^ anObject


### PR DESCRIPTION
Methods to replace the original object by the proxy in both proxy classes.
One test added ofr the delegation proxy but not the  forwarding proxy, as it would mean duplicating the code. 
Instead that should (later) be handled by another object.