### PR TITLE
Update avatar to make tests pass on Pharo 9

### DIFF
--- a/Avatar.package/AvDelegationClassProxyTest.class/instance/testCatchMessageRecursively.st
+++ b/Avatar.package/AvDelegationClassProxyTest.class/instance/testCatchMessageRecursively.st
@@ -4,10 +4,11 @@ testCatchMessageRecursively
 	handler := AvTestLogAndResendHandler new.
 	self newProxy displayString.
 	
-	self assert: handler messages size equals: 6.
+	self assert: handler messages size equals: 7.
 	self assert: handler messages first selector equals: #displayString.
-	self assert: handler messages second selector equals: #printString.
-	self assert: handler messages third selector equals: #printStringLimitedTo:.
-	self assert: handler messages fourth selector equals: #printOn:.
-	self assert: handler messages fifth selector equals: #name.
-	self assert: handler messages sixth selector equals: #instVarAt:.
+	self assert: handler messages second selector equals: #displayStringLimitedTo:.
+	self assert: handler messages third selector equals: #printStringLimitedTo:using:.
+	self assert: handler messages fourth selector equals: #displayStringOn:.
+	self assert: handler messages fifth selector equals: #printOn:.
+	self assert: handler messages sixth selector equals: #name.
+	self assert: handler messages seventh selector equals: #instVarAt:.

--- a/Avatar.package/AvDelegationMethodProvider.class/instance/delegationMethodFor.primitivesToRewrite..st
+++ b/Avatar.package/AvDelegationMethodProvider.class/instance/delegationMethodFor.primitivesToRewrite..st
@@ -2,26 +2,28 @@ accessing
 delegationMethodFor: aMethod primitivesToRewrite: aBlock
 
 	"This method creates a new method rewritten when a primitive is call or when a inst variable is assigned. It receives a block that is evaluated in the method, to check if the primitive should be rewriten or not"
-	
+
 	| delegationMethod |
 	(aBlock value: aMethod) ifTrue: [ ^ self rewritePrimitive: aMethod ].
 	aMethod hasInstVarRef ifFalse: [ ^ aMethod ].
-	
+
 	delegationMethod := aMethod ast copy.
 	delegationMethod nodesDo: [ :node | 
-		(node isVariable and: [ node isInstance ])
-			ifTrue: [
-				node parent isAssignment
-					ifTrue: [ node parent replaceWith: (RBMessageNode
-																	receiver: (RBSelfNode named: 'self')
-																	selector: #instVarAt:put:
-																	arguments: { 
-																		RBLiteralValueNode value: node binding slot index.
-																		node parent value }) ]
-					ifFalse: [ node replaceWith: (RBMessageNode
-															receiver: (RBSelfNode named: 'self')
-															selector: #instVarAt:
-															arguments: { RBLiteralValueNode value: node binding slot index }) ] ] ].
+		(node isVariable and: [ node isInstanceVariable ]) ifTrue: [ 
+			node parent isAssignment
+				ifTrue: [ 
+					node parent replaceWith: (RBMessageNode
+							 receiver: (RBSelfNode named: 'self')
+							 selector: #instVarAt:put:
+							 arguments: { 
+									 (RBLiteralValueNode value: node binding index).
+									 node parent value }) ]
+				ifFalse: [ 
+					node replaceWith: (RBMessageNode
+							 receiver: (RBSelfNode named: 'self')
+							 selector: #instVarAt:
+							 arguments:
+							 { (RBLiteralValueNode value: node binding index) }) ] ] ].
 	^ OpalCompiler new
-		class: aMethod methodClass;
-		compile: delegationMethod formattedCode
+		  class: aMethod methodClass;
+		  compile: delegationMethod formattedCode

--- a/Avatar.package/AvDelegationProxyTest.class/instance/testCatchMessageRecursively.st
+++ b/Avatar.package/AvDelegationProxyTest.class/instance/testCatchMessageRecursively.st
@@ -4,9 +4,10 @@ testCatchMessageRecursively
 	handler := AvTestLogAndResendHandler new.
 	self newProxy displayString.
 	
-	self assert: handler messages size equals: 6.
+	self assert: handler messages size equals: 7.
 	self assert: handler messages first selector equals: #displayString.
-	self assert: handler messages second selector equals: #printString.
-	self assert: handler messages third selector equals: #printStringLimitedTo:.
-	self assert: handler messages fourth selector equals: #printOn:.
-	self assert: handler messages fifth selector equals: #class.
+	self assert: handler messages second selector equals: #displayStringLimitedTo:.
+	self assert: handler messages third selector equals: #printStringLimitedTo:using:.
+	self assert: handler messages fourth selector equals: #displayStringOn:.
+	self assert: handler messages fifth selector equals: #printOn:.
+	self assert: handler messages sixth selector equals: #class.

--- a/Avatar.package/AvInstanceDelegationProxyClassTest.class/instance/testCatchIntanceVariableWrite.st
+++ b/Avatar.package/AvInstanceDelegationProxyClassTest.class/instance/testCatchIntanceVariableWrite.st
@@ -5,8 +5,9 @@ testCatchIntanceVariableWrite
 	handler := AvTestLogAndResendHandler new.
 	self newProxy superclass: nil.
 	
-	self assert: handler messages size equals: 2.
+	self assert: handler messages size equals: 3.
 	self assert: handler messages first selector equals: #superclass:.
+	self assert: handler messages second selector equals: #basicSuperclass:.
 	
-	self assert: handler messages second selector equals: #instVarAt:put:.
-	self assert: handler messages second arguments asArray equals: #( 1 nil ).
+	self assert: handler messages third selector equals: #instVarAt:put:.
+	self assert: handler messages third arguments asArray equals: #( 1 nil ).

--- a/Avatar.package/AvInstanceDelegationProxyClassTest.class/instance/testCatchMessageRecursively.st
+++ b/Avatar.package/AvInstanceDelegationProxyClassTest.class/instance/testCatchMessageRecursively.st
@@ -4,9 +4,11 @@ testCatchMessageRecursively
 	handler := AvTestLogAndResendHandler new.
 	self newProxy displayString.
 	
+	self assert: handler messages size equals: 7.
 	self assert: handler messages first selector equals: #displayString.
-	self assert: handler messages second selector equals: #printString.
-	self assert: handler messages third selector equals: #printStringLimitedTo:.
-	self assert: handler messages fourth selector equals: #printOn:.
-	self assert: handler messages fifth selector equals: #name.
-	self assert: handler messages sixth selector equals: #instVarAt:.
+	self assert: handler messages second selector equals: #displayStringLimitedTo:.
+	self assert: handler messages third selector equals: #printStringLimitedTo:using:.
+	self assert: handler messages fourth selector equals: #displayStringOn:.
+	self assert: handler messages fifth selector equals: #printOn:.
+	self assert: handler messages sixth selector equals: #name.
+	self assert: handler messages seventh selector equals: #instVarAt:.


### PR DESCRIPTION
Update AvDelegationMethodProvider to fix the access to the index of a slot : `node binding slot index` => `node binding index`
Update tests relying on a list of messages sent when  :
- calling `superclass`  : addition of a `basicSuperclass` message
- calling `displayString` : replacing messages between `displayString` and `printOn:` by `displayStringLimitedTo:`, `printStringLimitedTo:using:` and `displayStringOn:`